### PR TITLE
Make disks wider for longer disk names

### DIFF
--- a/widgets/handlers/disks/disks.go
+++ b/widgets/handlers/disks/disks.go
@@ -125,7 +125,7 @@ func process(items []fsItem) string {
 			nameColumnSize = l
 		}
 	}
-	nameColumnSizeWithPadding := int(math.Min(13, float64(nameColumnSize+6)))
+	nameColumnSizeWithPadding := int(math.Max(13, float64(nameColumnSize+6)))
 	buf := new(bytes.Buffer)
 	w := bufio.NewWriter(buf)
 	fmt.Fprint(w, padRight("Filesystems", " ", nameColumnSizeWithPadding))


### PR DESCRIPTION
I believe it should be `Max`, not `Min`. That should solve the problem with too long disk names:

![screenshot 2018-12-05 at 16 32 44](https://user-images.githubusercontent.com/6072721/49524139-791f7180-f8ab-11e8-9b9e-adbaff0fcb6b.png)
